### PR TITLE
replaces all versions of nodejs to 10.x

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ service: aws-emr-customized-scaling # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   stage: ${opt:stage, 'dev'}
   region: ${file(./config.${self:provider.stage}.json):region}
 


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #2 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
